### PR TITLE
github actions has some limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,25 +11,9 @@ environmental setup has already been performed.
 ```yaml
 - uses: knative-sandbox/downstream-test-go@v1
   with:
-    # Upstream Repository. For example, knative/pkg
-    # Default: ${{ github.repository }}
-    upstream-repository: ""
-
-    # The branch, tag or SHA to checkout for upstream-repository.
-    # Defaults are the same as actions/checkout@v2.ref.
-    upstream-ref: ""
-
     # Upstream Module. For example, knative.dev/pkg
     # Required.
     upstream-module: ""
-
-    # Downstream Repository. For example, knative-sandbox/sample-controller
-    # Required.
-    downstream-repository: ""
-
-    # The branch, tag or SHA to checkout for downstream-repository.
-    # Defaults are the same as actions/checkout@v2.ref.
-    downstream-ref: ""
 
     # Downstream Module. For example, knative.dev/sample-controller
     # Required.
@@ -43,7 +27,6 @@ environmental setup has already been performed.
 ```yaml
 - uses: knative-sandbox/downstream-test-go@v1
   with:
-    upstream-module: "knative.dev/pkg"
-    downstream-repository: "knative-sandbox/sample-controller"
-    downstream-module: "knative.dev/sample-controller"
+    upstream-module: knative.dev/pkg
+    downstream-module: knative.dev/sample-controller
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -1,25 +1,10 @@
 name: 'downstream-test-go'
 description: 'Test Downstream Go Modules with Upstream Go Modules.'
 inputs:
-  upstream-repository:
-    description: 'Upstream Repository. For example, knative/pkg'
-    required: false
-    default: '${{ github.repository }}'
-  upstream-ref:
-    description: >
-      The branch, tag or SHA to checkout for upstream-repository.
-      Defaults are the same as actions/checkout@v2.ref.
   upstream-module:
     description: 'Upstream Module. For example, knative.dev/pkg'
     required: true
 
-  downstream-repository:
-    description: 'Downstream Repository. For example, knative-sandbox/sample-controller'
-    required: true
-  downstream-ref:
-    description: >
-      The branch, tag or SHA to checkout for downstream-repository.
-      Defaults are the same as actions/checkout@v2.ref.
   downstream-module:
     description: 'Downstream Module. For example, knative.dev/sample-controller'
     required: true
@@ -27,19 +12,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout Upstream
-      uses: actions/checkout@v2
-      with:
-        repository: ${{ inputs.upstream-repository }}
-        path: './src/${{ inputs.upstream-module }}'
-        ref: ${{ inputs.upstream-ref }}
-
-    - name: Checkout Downstream
-      uses: actions/checkout@v2
-      with:
-        repository: ${{ inputs.downstream-repository }}
-        path: './src/${{ inputs.downstream-module }}'
-        ref: ${{ inputs.downstream-ref }}
 
     - name: Update Downstream, Replace Upstream with Local Upstream
       shell: bash


### PR DESCRIPTION
It turns out, you can't composite actions together that are imports. The composite is only for bash scripts or embedded bash. Checkout will have to happen in the caller